### PR TITLE
fix(ci): TeXLive setup

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Setup TeX Live
       if: ${{ env.USES_TEX == 'true' }}
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: zauguin/install-texlive@v4
       with:
         packages: >-
           amsmath


### PR DESCRIPTION
Looks like the action we used to set up the TeXLive installation was removed from GitHub. We now use another action.

Closes #4
